### PR TITLE
Improve all the things?

### DIFF
--- a/drun.sh
+++ b/drun.sh
@@ -10,7 +10,7 @@ drun () {
 		[ -z "$command" ] && continue
 
 		# shellcheck disable=SC2091
-		$(grep -E '^Exec' "$command" | tail -1 | sed 's/^Exec=//' | sed 's/%.//' | sed 's/^"//g' | sed 's/" *$//g') > /dev/null 2>&1 &
+		$(grep -E '^Exec' "$command" | tail -1 | sed -e 's/^Exec=//' -e 's/%.//'  -e 's/^"//g' -e 's/" *$//g') > /dev/null 2>&1 &
 	done
 	xdotool search --onlyvisible --name "drun.shfuzzy" windowunmap
 }

--- a/drun.sh
+++ b/drun.sh
@@ -5,7 +5,7 @@ format_xdg_data_dirs() {
 drun () {
     [ -z "$XDG_DATA_DIRS" ] && XDG_DATA_DIRS="/usr/share:$HOME/.local/share"
     # shellcheck disable=SC2046
-	find $(format_xdg_data_dirs) -iname "*.desktop" | fzf --reverse --multi --preview  'cat {}' | while read -r command
+	find $(format_xdg_data_dirs) -iname "*.desktop" 2> /dev/null | fzf --reverse --multi --preview  'cat {}' | while read -r command
 	do
 		[ -z "$command" ] && continue
 

--- a/pdf.sh
+++ b/pdf.sh
@@ -1,9 +1,11 @@
 func () {
-	local file="$(find ~/Books/ -type f -iname '*.pdf' | fzf --reverse --multi --preview 'pdftotext -l 10 {} -')"
-	local files
-	[[ -n "$file" ]] && readarray -t files <<< "$file"
+	find ~/Books/ -type f -iname '*.pdf' | fzf --reverse --multi --preview 'pdftotext -l 10 {} -' | while read -r book
+	do
+		[ -z "$book" ] && continue
 
-	nohup zathura "${files[@]}" &> /dev/null &
+		nohup zathura "$book" > /dev/null 2>&1 &
+	done
+
 	xdotool search --onlyvisible --name "pdf.shfuzzy" windowunmap
 }
 

--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@ run () {
 	[ -n "$ZSH_VERSION"  ] && func="zsh_list_commands"
 	[ -z "$func" ] && func="posix_list_commands"
 
-	$func | fzf --print-query --reverse --multi | while read -r command
+	$func | fzf --print-query --reverse --multi | sort -u | while read -r command
 	do
 		[ -z "$command" ] && continue
 


### PR DESCRIPTION
This should be quicker since it doesn't use bashes arrays (it actually doesn't use any bash at all - except when it's run by bash - and should work in any POSIX shell).

I've also made drun use the `XDG_DATA_DIRS` variable instead of hardcoding the search path. This is important if you were to use any `snap` or `flatpak` applications since they place .desktop files elsewhere (for example flatpak uses `$HOME/.local/share/flatpak/exports/share/applications` and `/var/lib/flatpak/exports/share/applications`).